### PR TITLE
動作をシンプルにしてテスト #6

### DIFF
--- a/Jishin.php
+++ b/Jishin.php
@@ -37,19 +37,22 @@ foreach($xml_tree->channel->item as $k => $v){
   $pubtime = date('Y-m-d H:i:s',strtotime((string)$v->pubDate));
   
 
-//以下テストのためいったんコメントアウト
-//  if ($pubtime <= $last_pubtime){
-//continue;
-//  }
+  if ($pubtime <= $last_pubtime){ //処理済みitemはスルーして次へ
+    continue;
+  }
  
-//  if ($pubtime < date('Y-m-d H:i:s',time() - 900)){//前回から15分（900秒）以内なら処理しないで次へ
-//continue;//TEST時はここをコメントアウト
-//  }
+  if ($pubtime < date('Y-m-d H:i:s',time() - 900)){ //前回から15分（900秒）以内でなければ処理しないで次へ
+    continue;
+  }
  
-  //震度を取得し、指定以上ならフラグ立て、処理を終了
+//  //震度を取得し、指定以上ならフラグ立て、処理を終了
+//  preg_match('/震度([0-9]+)[強弱]*/',$text,$matches);
+//  preg_match('/\[震源地\](.*)\[最大震度\]/',$text,$matches_basyo);
+//  preg_match('/\(20(.*)分頃発生/',$text,$matches_time);
+//  //テスト用に抜き出し部分を加工
   preg_match('/震度([0-9]+)[強弱]*/',$text,$matches);
   preg_match('/\[震源地\](.*)\[最大震度\]/',$text,$matches_basyo);
-  preg_match('/\(20(.*)分頃発生/',$text,$matches_time);
+  preg_match('/\日(.*)分頃発生/',$text,$matches_time);
   $shindo = $matches[1];
  
   if (is_numeric($shindo) && (int)$shindo >= 1){//テストのため震度1でも動作するようにする
@@ -59,13 +62,15 @@ $result['pubtime'] = $pubtime;
 $result['text'] = $text;
 $result['basyo'] = trim($matches_basyo[1],"　");
 $result['time'] = trim($matches_time[1],"　");
-$result['word'] = "字、字……、いや、地震ですかっ!　20".$result['time']."分ころ".$result['basyo']."あたりで".$result['str']."くらい？"; //ツィートされます。
-//$result['word'] = "字、字……、いや、地震ですかっ!　".$shindo_basyo."あたりで".$shindo_str."くらい？"; //ツィートされます。
+$result['word'] = "@dezaiso もう".$result['time']."分過ぎちゃいましたよね…"; //テスト
+// $result['word'] = "字、字……、いや、地震ですかっ!　20".$result['time']."分ころ".$result['basyo']."あたりで".$result['str']."くらい？"; //ツィートされます。
+//$result['word'] = "字、字……、いや、地震ですかっ!　".$shindo_basyo."あたりで".$shindo_str."くらい？"; //変数読み込めず
 break;
 }
   }
  
-echo $result['word']."<br /><br />";
+// 確認用
+// echo $result['word']."<br />".$shindo."<br /><br />";
 
 //地震ファイルを用意し、書き換える
 $jishinmemo = $result['word'];

--- a/bot.php
+++ b/bot.php
@@ -19,11 +19,10 @@ $ebo = new Easy_botter_org();
 // 状態フラグ $joutai
 //    [0]quake:地震が起きた
 //=============================
-    $joutai_txt = file_get_contents("Jishin_joutai.txt");
-    if($joutai_txt !== ""){
-        $joutai = unserialize($joutai_txt);
-	}
-	
+//    $joutai_txt = file_get_contents("Jishin_joutai.txt");
+//    if($joutai_txt !== ""){
+//        $joutai = unserialize($joutai_txt);
+//	}
 //=============================
 //地震のときに停止するならコメントアウトを外すこと。
 //=============================
@@ -38,26 +37,34 @@ $ebo = new Easy_botter_org();
  
 $shindo = $ebo->jisin();
  
-if( $shindo['num'] > 0){ //値が返ってきてたら
-  $joutai[0] = TRUE; //「地震が起きた」フラグを立てる
-}
+//if( $shindo['num'] > 0){ //値が返ってきてたら
+//  $joutai[0] = TRUE; //「地震が起きた」フラグを立てる
+//}
  
 //=============================
 //フラグファイル格納。
 //=============================
-    $response = file_put_contents("Jishin_joutai.txt" , serialize($joutai));
+//    $response = file_put_contents("Jishin_joutai.txt" , serialize($joutai));
  
 //=============================
 //地震についてツイート。（動作未確認）
 //=============================
-if($dousa[0] !== NULL){
-    if($dousa[0]['word'] !== ""){
-        $response = $eb->setUpdate(array("status"=>$dousa[30]['word']));
- 
-    } else if($dousa[0]['data'] !== ""){
-        $response = $eb->postRandom($dousa[0]['data']);
-    }
+// if($dousa[0] !== NULL){
+//     if($dousa[0]['word'] !== ""){
+//         $response = $eb->setUpdate(array("status"=>$dousa[30]['word']));
+//  
+//     } else if($dousa[0]['data'] !== ""){
+//         $response = $eb->postRandom($dousa[0]['data']);
+//     }
+// }
+
+if($shindo >= 1){
+	$response = $eb->postRandom("jishin.txt");
+	$fp = fopen("jishin.txt", "w"); // ツイート後すぐに初期化
+	fwrite($fp, "");
+	fclose($fp);
 }
+
 
 //=============================
 //地震関連ここまで


### PR DESCRIPTION
- 地震を受けても止めないので動作しているかどうかフラグを立てる必要がない
- 地震の情報をとってきでファイルに格納 → ツイートのみの動作でよい
- 重複チェックは pubtime の比較によって
- 実際にサーバに置いてテスト。震度1以上の場合ダミーツイートをするようにした。
